### PR TITLE
Add support for dot-language-server if found in PATH

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "zed_dot"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+[lib]
+path = "src/dot.rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+zed_extension_api = "0.2.0"

--- a/extension.toml
+++ b/extension.toml
@@ -9,3 +9,7 @@ repository = "https://github.com/gabeidx/zed-graphviz"
 [grammars.dot]
 repository = "https://github.com/rydesun/tree-sitter-dot"
 commit = "9ab85550c896d8b294d9b9ca1e30698736f08cea"
+
+[language_servers.dot-language-server]
+name = "Graphviz DOT LSP"
+language = "DOT"

--- a/src/dot.rs
+++ b/src/dot.rs
@@ -1,0 +1,51 @@
+use zed::settings::LspSettings;
+use zed_extension_api::{self as zed, serde_json, LanguageServerId, Result};
+
+struct DotLspExtension {}
+
+impl DotLspExtension {
+    fn language_server_binary_path(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<String> {
+        worktree
+            .which("dot-language-server")
+            .ok_or(String::from("Ensure dot-language-server is in PATH"));
+    }
+}
+
+impl zed::Extension for DotLspExtension {
+    fn new() -> Self {
+        Self {}
+    }
+
+    fn language_server_command(
+        &mut self,
+        language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<zed::Command> {
+        Ok(zed::Command {
+            command: self.language_server_binary_path(language_server_id, worktree)?,
+            args: vec![String::from("--stdio")],
+            env: Default::default(),
+        })
+    }
+
+    fn language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &zed::LanguageServerId,
+        worktree: &zed::Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        let settings = LspSettings::for_worktree("dot-language-server", worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.settings.clone())
+            .unwrap_or_default();
+
+        Ok(Some(serde_json::json!({
+            "dot-language-server": settings
+        })))
+    }
+}
+
+zed::register_extension!(DotLspExtension);


### PR DESCRIPTION
Closes #4 

No automatic downloading, either put dot-language-server in PATH or specify the binary path in your Zed config (should work, not tested). A fancier implementation might fetch the latest tag from npm but I don't want to bother with that right now.